### PR TITLE
refactor: simplify asset handling by removing unnecessary abstractions

### DIFF
--- a/internal/asset.go
+++ b/internal/asset.go
@@ -46,13 +46,11 @@ func (a *Asset) BinaryName() string {
 func parseAsset(assets []*github.ReleaseAsset, cfg *Config, repoOwner, repoName string) (*Asset, error) {
 	logger.Info("Parsing %d release assets for %s_%s", len(assets), cfg.OS, cfg.Arch)
 
-	unpacker := NewUnpacker()
-
 	for _, a := range assets {
 		name := strings.ToLower(*a.Name)
 		logger.Info("Evaluating asset: %s", name)
 
-		if MatchesPlatform(name, cfg.OS, cfg.Arch, cfg.OSAliases, cfg.ArchAliases) && unpacker.IsSupportedFormat(name) {
+		if MatchesPlatform(name, cfg.OS, cfg.Arch, cfg.OSAliases, cfg.ArchAliases) && IsSupportedFormat(name) {
 			logger.Info("Found compatible asset: %s", name)
 			return &Asset{
 				Name:        name,
@@ -82,26 +80,19 @@ func InstallAsset(ctx context.Context, asset *Asset, cfg *Config, httpClient *ht
 	}()
 
 	// Download asset
-	downloader := NewDownloader(httpClient)
 	archivePath := filepath.Join(ws.DownloadDir(), asset.Name)
-	if err := downloader.Download(ctx, asset.DownloadURL, ws.DownloadDir(), asset.Name); err != nil {
+	if err := Download(ctx, httpClient, asset.DownloadURL, ws.DownloadDir(), asset.Name); err != nil {
 		return fmt.Errorf("download: %w", err)
 	}
 
 	// Unpack archive
-	unpacker := NewUnpacker()
-	execPath, err := unpacker.Unpack(archivePath, ws.UnpackDir())
+	execPath, err := Unpack(archivePath, ws.UnpackDir())
 	if err != nil {
 		return fmt.Errorf("unpack: %w", err)
 	}
 
 	// Install binary
-	installer, err := NewBinaryInstaller(cfg.BinDir)
-	if err != nil {
-		return fmt.Errorf("create installer: %w", err)
-	}
-
-	if err := installer.Install(execPath, asset.BinaryName()); err != nil {
+	if err := InstallBinary(execPath, cfg.BinDir, asset.BinaryName()); err != nil {
 		return fmt.Errorf("install: %w", err)
 	}
 

--- a/internal/asset_test.go
+++ b/internal/asset_test.go
@@ -664,6 +664,21 @@ func bzip2Compress(t *testing.T, data []byte) []byte {
 	return out.Bytes()
 }
 
+// createTestTarBz2 builds an in-memory .tar.bz2 containing a mock Mach-O executable.
+// The test that calls this helper is skipped when bzip2 is not available on the host.
+func createTestTarBz2(t *testing.T) []byte {
+	t.Helper()
+	var tarBuf bytes.Buffer
+	tw := tar.NewWriter(&tarBuf)
+	content := append(machOBinary(), make([]byte, 1000)...)
+	hdr := &tar.Header{Name: "test-executable", Mode: 0o755, Size: int64(len(content))}
+	require.NoError(t, tw.WriteHeader(hdr))
+	_, err := tw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	return bzip2Compress(t, tarBuf.Bytes())
+}
+
 // createTestTarXz builds an in-memory .tar.xz containing a mock Mach-O executable.
 func createTestTarXz(t *testing.T) []byte {
 	t.Helper()
@@ -993,6 +1008,21 @@ func TestUnpackerUnpackTarXz(t *testing.T) {
 
 	archivePath := filepath.Join(tempDir, "test.tar.xz")
 	require.NoError(t, os.WriteFile(archivePath, createTestTarXz(t), 0o644))
+
+	execPath, err := Unpack(archivePath, filepath.Join(tempDir, "out"))
+	assert.NoError(t, err)
+	assert.NotEmpty(t, execPath)
+	assert.FileExists(t, execPath)
+}
+
+// TestUnpackerUnpackTarBz2 tests Unpacker.Unpack end-to-end for the .tar.bz2 format.
+// The test is skipped when bzip2 is not available on the host.
+func TestUnpackerUnpackTarBz2(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+
+	archivePath := filepath.Join(tempDir, "test.tar.bz2")
+	require.NoError(t, os.WriteFile(archivePath, createTestTarBz2(t), 0o644))
 
 	execPath, err := Unpack(archivePath, filepath.Join(tempDir, "out"))
 	assert.NoError(t, err)

--- a/internal/asset_test.go
+++ b/internal/asset_test.go
@@ -146,12 +146,11 @@ func TestDownloader(t *testing.T) {
 			tc.mockSetup(mockTransport)
 
 			httpClient := newMockHTTPClient(mockTransport)
-			downloader := NewDownloader(httpClient)
 			destDir := filepath.Join(os.TempDir(), "test-download-"+tc.filename)
 			defer os.RemoveAll(destDir)
 
 			ctx := context.Background()
-			err := downloader.Download(ctx, tc.downloadURL, destDir, tc.filename)
+			err := Download(ctx, httpClient, tc.downloadURL, destDir, tc.filename)
 
 			if tc.expectError {
 				assert.Error(t, err)
@@ -192,9 +191,8 @@ func TestUnpacker(t *testing.T) {
 		require.NoError(t, os.WriteFile(archivePath, tarData, 0644))
 
 		// Unpack
-		unpacker := NewUnpacker()
 		destDir := filepath.Join(tempDir, "output")
-		execPath, err := unpacker.Unpack(archivePath, destDir)
+		execPath, err := Unpack(archivePath, destDir)
 
 		assert.NoError(t, err)
 		assert.NotEmpty(t, execPath)
@@ -211,9 +209,8 @@ func TestUnpacker(t *testing.T) {
 		archivePath := filepath.Join(tempDir, "test.txt")
 		require.NoError(t, os.WriteFile(archivePath, []byte("not an archive"), 0644))
 
-		unpacker := NewUnpacker()
 		destDir := filepath.Join(tempDir, "output")
-		_, err := unpacker.Unpack(archivePath, destDir)
+		_, err := Unpack(archivePath, destDir)
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "unsupported archive format")
@@ -222,13 +219,11 @@ func TestUnpacker(t *testing.T) {
 	t.Run("IsSupportedFormat", func(t *testing.T) {
 		t.Parallel()
 
-		unpacker := NewUnpacker()
-
-		assert.True(t, unpacker.IsSupportedFormat("test.tar.gz"))
-		assert.True(t, unpacker.IsSupportedFormat("test.zip"))
-		assert.True(t, unpacker.IsSupportedFormat("test.tar.bz2"))
-		assert.False(t, unpacker.IsSupportedFormat("test.txt"))
-		assert.False(t, unpacker.IsSupportedFormat("test.exe"))
+		assert.True(t, IsSupportedFormat("test.tar.gz"))
+		assert.True(t, IsSupportedFormat("test.zip"))
+		assert.True(t, IsSupportedFormat("test.tar.bz2"))
+		assert.False(t, IsSupportedFormat("test.txt"))
+		assert.False(t, IsSupportedFormat("test.exe"))
 	})
 }
 
@@ -249,10 +244,7 @@ func TestBinaryInstaller(t *testing.T) {
 
 		// Install
 		binDir := filepath.Join(tempDir, "bin")
-		installer, err := NewBinaryInstaller(binDir)
-		require.NoError(t, err)
-
-		err = installer.Install(srcPath, "test-binary")
+		err := InstallBinary(srcPath, binDir, "test-binary")
 		assert.NoError(t, err)
 
 		// Verify
@@ -267,7 +259,7 @@ func TestBinaryInstaller(t *testing.T) {
 	t.Run("invalid bin directory", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := NewBinaryInstaller("")
+		err := InstallBinary("dummy-src", "", "name")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot be empty")
 	})
@@ -275,7 +267,7 @@ func TestBinaryInstaller(t *testing.T) {
 	t.Run("relative path rejected", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := NewBinaryInstaller("relative/path")
+		err := InstallBinary("dummy-src", "relative/path", "name")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "must be absolute path")
 	})
@@ -569,9 +561,8 @@ func TestUnpackerZipSlip(t *testing.T) {
 			archivePath := filepath.Join(tempDir, "evil.tar.gz")
 			require.NoError(t, os.WriteFile(archivePath, data, 0644))
 
-			unpacker := NewUnpacker()
 			destDir := filepath.Join(tempDir, "output")
-			_, err := unpacker.Unpack(archivePath, destDir)
+			_, err := Unpack(archivePath, destDir)
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "path traversal attempt")
 		})
@@ -585,9 +576,8 @@ func TestUnpackerZipSlip(t *testing.T) {
 			archivePath := filepath.Join(tempDir, "evil.zip")
 			require.NoError(t, os.WriteFile(archivePath, data, 0644))
 
-			unpacker := NewUnpacker()
 			destDir := filepath.Join(tempDir, "output")
-			_, err := unpacker.Unpack(archivePath, destDir)
+			_, err := Unpack(archivePath, destDir)
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), "path traversal attempt")
 		})
@@ -977,8 +967,7 @@ func TestUnpackerNoExecutableFound(t *testing.T) {
 	archivePath := filepath.Join(tempDir, "noexec.tar.gz")
 	require.NoError(t, os.WriteFile(archivePath, buf.Bytes(), 0o644))
 
-	unpacker := NewUnpacker()
-	_, err = unpacker.Unpack(archivePath, filepath.Join(tempDir, "out"))
+	_, err = Unpack(archivePath, filepath.Join(tempDir, "out"))
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no executable found in archive")
 }
@@ -991,8 +980,7 @@ func TestUnpackerUnpackZip(t *testing.T) {
 	archivePath := filepath.Join(tempDir, "test.zip")
 	require.NoError(t, os.WriteFile(archivePath, createTestZipWithExec(t), 0o644))
 
-	unpacker := NewUnpacker()
-	execPath, err := unpacker.Unpack(archivePath, filepath.Join(tempDir, "out"))
+	execPath, err := Unpack(archivePath, filepath.Join(tempDir, "out"))
 	assert.NoError(t, err)
 	assert.NotEmpty(t, execPath)
 	assert.FileExists(t, execPath)
@@ -1006,8 +994,7 @@ func TestUnpackerUnpackTarXz(t *testing.T) {
 	archivePath := filepath.Join(tempDir, "test.tar.xz")
 	require.NoError(t, os.WriteFile(archivePath, createTestTarXz(t), 0o644))
 
-	unpacker := NewUnpacker()
-	execPath, err := unpacker.Unpack(archivePath, filepath.Join(tempDir, "out"))
+	execPath, err := Unpack(archivePath, filepath.Join(tempDir, "out"))
 	assert.NoError(t, err)
 	assert.NotEmpty(t, execPath)
 	assert.FileExists(t, execPath)

--- a/internal/binary_installer.go
+++ b/internal/binary_installer.go
@@ -7,36 +7,34 @@ import (
 	"path/filepath"
 )
 
-// BinaryInstaller handles installing binary executables to a target directory
-type BinaryInstaller struct {
-	binDir string
-}
-
-// NewBinaryInstaller creates a new BinaryInstaller for the given binary directory
-func NewBinaryInstaller(binDir string) (*BinaryInstaller, error) {
+// InstallBinary copies the executable at srcPath into binDir with the given
+// binaryName and sets executable permissions (0755).
+func InstallBinary(srcPath, binDir, binaryName string) error {
 	if binDir == "" {
-		return nil, fmt.Errorf("binary directory cannot be empty")
+		return fmt.Errorf("binary directory cannot be empty")
 	}
 
 	if !filepath.IsAbs(binDir) {
-		return nil, fmt.Errorf("binary directory must be absolute path: %s", binDir)
+		return fmt.Errorf("binary directory must be absolute path: %s", binDir)
 	}
 
 	if err := os.MkdirAll(binDir, 0755); err != nil {
-		return nil, fmt.Errorf("create binary directory: %w", err)
+		return fmt.Errorf("create binary directory: %w", err)
 	}
 
-	return &BinaryInstaller{
-		binDir: binDir,
-	}, nil
-}
+	srcInfo, err := os.Stat(srcPath)
+	if err != nil {
+		return fmt.Errorf("source binary not found: %w", err)
+	}
 
-// Install copies an executable to the binary directory and sets proper permissions
-// srcPath is the path to the source executable
-// binaryName is the name the binary should have in the bin directory
-func (b *BinaryInstaller) Install(srcPath, binaryName string) error {
-	if err := b.validateSource(srcPath); err != nil {
-		return err
+	if srcInfo.IsDir() {
+		return fmt.Errorf("source is a directory, not a file: %s", srcPath)
+	}
+
+	if srcInfo.Mode()&0111 == 0 {
+		if err := os.Chmod(srcPath, 0755); err != nil {
+			return fmt.Errorf("source is not executable and cannot set permissions: %w", err)
+		}
 	}
 
 	src, err := os.Open(srcPath)
@@ -45,12 +43,7 @@ func (b *BinaryInstaller) Install(srcPath, binaryName string) error {
 	}
 	defer src.Close()
 
-	srcInfo, err := src.Stat()
-	if err != nil {
-		return fmt.Errorf("stat source binary: %w", err)
-	}
-
-	destPath := filepath.Join(b.binDir, binaryName)
+	destPath := filepath.Join(binDir, binaryName)
 	dest, err := os.Create(destPath)
 	if err != nil {
 		return fmt.Errorf("create destination binary: %w", err)
@@ -58,8 +51,7 @@ func (b *BinaryInstaller) Install(srcPath, binaryName string) error {
 	defer dest.Close()
 
 	bar := NewProgressBar(int(srcInfo.Size()), "[cyan][3/3][reset] Installing")
-	_, err = io.Copy(io.MultiWriter(dest, bar), src)
-	if err != nil {
+	if _, err = io.Copy(io.MultiWriter(dest, bar), src); err != nil {
 		return fmt.Errorf("copy binary: %w", err)
 	}
 	fmt.Println() // new line after progress bar
@@ -69,31 +61,4 @@ func (b *BinaryInstaller) Install(srcPath, binaryName string) error {
 	}
 
 	return nil
-}
-
-// validateSource ensures the source path is valid and executable
-func (b *BinaryInstaller) validateSource(srcPath string) error {
-	info, err := os.Stat(srcPath)
-	if err != nil {
-		return fmt.Errorf("source binary not found: %w", err)
-	}
-
-	if info.IsDir() {
-		return fmt.Errorf("source is a directory, not a file: %s", srcPath)
-	}
-
-	// Check if file has execute permission
-	if info.Mode()&0111 == 0 {
-		// Try to set execute permission
-		if err := os.Chmod(srcPath, 0755); err != nil {
-			return fmt.Errorf("source is not executable and cannot set permissions: %w", err)
-		}
-	}
-
-	return nil
-}
-
-// BinDir returns the binary installation directory
-func (b *BinaryInstaller) BinDir() string {
-	return b.binDir
 }

--- a/internal/downloader.go
+++ b/internal/downloader.go
@@ -9,62 +9,44 @@ import (
 	"path/filepath"
 )
 
-// Downloader handles downloading files from URLs
-type Downloader struct {
-	client *http.Client
-}
-
-// NewDownloader creates a new Downloader with the given HTTP client
-func NewDownloader(client *http.Client) *Downloader {
+// Download downloads a file from the given URL into destDir/filename.
+func Download(ctx context.Context, client *http.Client, url, destDir, filename string) error {
 	if client == nil {
 		client = &http.Client{}
 	}
-	return &Downloader{
-		client: client,
-	}
-}
 
-// Download downloads a file from the given URL to the destination path
-// Returns the full path to the downloaded file
-func (d *Downloader) Download(ctx context.Context, url, destPath, filename string) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}
 
-	res, err := d.client.Do(req)
+	res, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("download file: %w", err)
 	}
 	defer func() {
-		if closeErr := res.Body.Close(); closeErr != nil {
-			// TODO: use logger when available
-			_ = closeErr
-		}
+		_ = res.Body.Close()
 	}()
 
 	if res.StatusCode > 299 {
 		return fmt.Errorf("download failed with status %s", res.Status)
 	}
 
-	if err := os.MkdirAll(destPath, 0755); err != nil {
+	if err := os.MkdirAll(destDir, 0755); err != nil {
 		return fmt.Errorf("create download directory: %w", err)
 	}
 
-	fullPath := filepath.Join(destPath, filename)
+	fullPath := filepath.Join(destDir, filename)
 	f, err := os.Create(fullPath)
 	if err != nil {
 		return fmt.Errorf("create file: %w", err)
 	}
 	defer func() {
-		if closeErr := f.Close(); closeErr != nil {
-			_ = closeErr
-		}
+		_ = f.Close()
 	}()
 
 	bar := NewProgressBar(int(res.ContentLength), "[cyan][1/3][reset] Downloading")
-	_, err = io.Copy(io.MultiWriter(f, bar), res.Body)
-	if err != nil {
+	if _, err = io.Copy(io.MultiWriter(f, bar), res.Body); err != nil {
 		return fmt.Errorf("write file: %w", err)
 	}
 

--- a/internal/grip.go
+++ b/internal/grip.go
@@ -90,15 +90,13 @@ func SelfUpdate(ctx context.Context, version string) error {
 	defer ws.Cleanup()
 
 	// Download
-	downloader := NewDownloader(&http.Client{Timeout: 30 * time.Second})
-	if err := downloader.Download(ctx, asset.DownloadURL, ws.DownloadDir(), asset.Name); err != nil {
+	if err := Download(ctx, &http.Client{Timeout: 30 * time.Second}, asset.DownloadURL, ws.DownloadDir(), asset.Name); err != nil {
 		return fmt.Errorf("download: %w", err)
 	}
 
 	// Unpack
-	unpacker := NewUnpacker()
 	archivePath := filepath.Join(ws.DownloadDir(), asset.Name)
-	binPath, err := unpacker.Unpack(archivePath, ws.UnpackDir())
+	binPath, err := Unpack(archivePath, ws.UnpackDir())
 	if err != nil {
 		return fmt.Errorf("unpack: %w", err)
 	}

--- a/internal/unpack.go
+++ b/internal/unpack.go
@@ -43,6 +43,17 @@ var unpackers = map[string]unpackFn{
 	".bz2":     unpackBz2,
 }
 
+// orderedExts lists supported archive extensions sorted by descending length
+// so that longer suffixes (e.g. .tar.bz2) are matched before shorter ones (e.g. .bz2).
+var orderedExts = []string{
+	".tar.bz2",
+	".tar.gz",
+	".tar.xz",
+	".tbz",
+	".zip",
+	".bz2",
+}
+
 // Unpack extracts an archive file to the destination directory.
 // Returns the path to the executable binary found in the archive.
 func Unpack(archivePath, destDir string) (string, error) {
@@ -89,8 +100,9 @@ func Unpack(archivePath, destDir string) (string, error) {
 
 // IsSupportedFormat reports whether filename has a supported archive extension.
 func IsSupportedFormat(filename string) bool {
-	for ext := range unpackers {
-		if strings.HasSuffix(strings.ToLower(filename), ext) {
+	filename = strings.ToLower(filename)
+	for _, ext := range orderedExts {
+		if strings.HasSuffix(filename, ext) {
 			return true
 		}
 	}
@@ -100,9 +112,9 @@ func IsSupportedFormat(filename string) bool {
 // getUnpackFn returns the appropriate unpacker function for the filename.
 func getUnpackFn(filename string) (string, unpackFn, error) {
 	filename = strings.ToLower(filename)
-	for ext, fn := range unpackers {
+	for _, ext := range orderedExts {
 		if strings.HasSuffix(filename, ext) {
-			return ext, fn, nil
+			return ext, unpackers[ext], nil
 		}
 	}
 	return "", nil, fmt.Errorf("unsupported archive format: %s", filename)

--- a/internal/unpack.go
+++ b/internal/unpack.go
@@ -34,34 +34,24 @@ func sanitizePath(destination, name string) (string, error) {
 	return target, nil
 }
 
-// Unpacker handles extracting various archive formats
-type Unpacker struct {
-	unpackers map[string]unpackFn
+var unpackers = map[string]unpackFn{
+	".tar.gz":  unpackTarGz,
+	".tar.bz2": unpackTarBz2,
+	".tbz":     unpackTarBz2,
+	".zip":     unpackZip,
+	".tar.xz":  unpackTarXz,
+	".bz2":     unpackBz2,
 }
 
-// NewUnpacker creates a new Unpacker with support for common archive formats
-func NewUnpacker() *Unpacker {
-	return &Unpacker{
-		unpackers: map[string]unpackFn{
-			".tar.gz":  unpackTarGz,
-			".tar.bz2": unpackTarBz2,
-			".tbz":     unpackTarBz2,
-			".zip":     unpackZip,
-			".tar.xz":  unpackTarXz,
-			".bz2":     unpackBz2,
-		},
-	}
-}
-
-// Unpack extracts an archive file to the destination directory
-// Returns the path to the executable binary found in the archive
-func (u *Unpacker) Unpack(archivePath, destDir string) (string, error) {
+// Unpack extracts an archive file to the destination directory.
+// Returns the path to the executable binary found in the archive.
+func Unpack(archivePath, destDir string) (string, error) {
 	archiveInfo, err := os.Stat(archivePath)
 	if err != nil {
 		return "", fmt.Errorf("stat archive: %w", err)
 	}
 
-	ext, unpackFn, err := u.getUnpackFn(archivePath)
+	ext, fn, err := getUnpackFn(archivePath)
 	if err != nil {
 		return "", err
 	}
@@ -84,12 +74,12 @@ func (u *Unpacker) Unpack(archivePath, destDir string) (string, error) {
 	}
 
 	bar := NewProgressBar(int(archiveInfo.Size()), "[cyan][2/3][reset] Unpacking")
-	if err := unpackFn(archive, unpackDest, bar); err != nil {
+	if err := fn(archive, unpackDest, bar); err != nil {
 		return "", fmt.Errorf("unpack archive: %w", err)
 	}
 	fmt.Println() // new line after progress bar
 
-	execPath, err := u.findExecutable(destDir)
+	execPath, err := findExecutable(destDir)
 	if err != nil {
 		return "", fmt.Errorf("find executable: %w", err)
 	}
@@ -97,9 +87,9 @@ func (u *Unpacker) Unpack(archivePath, destDir string) (string, error) {
 	return execPath, nil
 }
 
-// IsSupportedFormat checks if the filename has a supported archive extension
-func (u *Unpacker) IsSupportedFormat(filename string) bool {
-	for ext := range u.unpackers {
+// IsSupportedFormat reports whether filename has a supported archive extension.
+func IsSupportedFormat(filename string) bool {
+	for ext := range unpackers {
 		if strings.HasSuffix(strings.ToLower(filename), ext) {
 			return true
 		}
@@ -107,10 +97,10 @@ func (u *Unpacker) IsSupportedFormat(filename string) bool {
 	return false
 }
 
-// getUnpackFn returns the appropriate unpacker function for the filename
-func (u *Unpacker) getUnpackFn(filename string) (string, unpackFn, error) {
+// getUnpackFn returns the appropriate unpacker function for the filename.
+func getUnpackFn(filename string) (string, unpackFn, error) {
 	filename = strings.ToLower(filename)
-	for ext, fn := range u.unpackers {
+	for ext, fn := range unpackers {
 		if strings.HasSuffix(filename, ext) {
 			return ext, fn, nil
 		}
@@ -118,8 +108,8 @@ func (u *Unpacker) getUnpackFn(filename string) (string, unpackFn, error) {
 	return "", nil, fmt.Errorf("unsupported archive format: %s", filename)
 }
 
-// findExecutable searches for an executable binary in the directory tree
-func (u *Unpacker) findExecutable(dir string) (string, error) {
+// findExecutable searches for an executable binary in the directory tree.
+func findExecutable(dir string) (string, error) {
 	fileTypes := map[string]bool{
 		"application/x-mach-binary": true,
 		"application/x-executable":  true,
@@ -132,7 +122,7 @@ func (u *Unpacker) findExecutable(dir string) (string, error) {
 		}
 
 		if !info.IsDir() {
-			mimeType, err := u.detectFileType(path)
+			mimeType, err := detectFileType(path)
 			if err != nil {
 				// Continue searching on error
 				return nil
@@ -158,8 +148,8 @@ func (u *Unpacker) findExecutable(dir string) (string, error) {
 	return executablePath, nil
 }
 
-// detectFileType detects the MIME type of a file
-func (u *Unpacker) detectFileType(path string) (string, error) {
+// detectFileType detects the MIME type of a file.
+func detectFileType(path string) (string, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
This pull request refactors the asset downloading, unpacking, and binary installation logic to use standalone functions instead of struct-based objects. This change simplifies the codebase by removing unnecessary abstractions and makes the code more straightforward and easier to test and maintain. All usages and tests have been updated to use the new function-based APIs.

Key changes include:

**Refactoring to function-based APIs:**

- Replaced the `Downloader` struct and its methods with a single `Download` function, updating all usages and tests accordingly. (`internal/downloader.go`, `internal/asset.go`, `internal/asset_test.go`, `internal/grip.go`) [[1]](diffhunk://#diff-d9f42243b52b71fb8b4517902e54cbe89279a824b3dfdc71d7ecb93437c9bc98L12-R49) [[2]](diffhunk://#diff-64810240c89ddea453b8fd27ed69184b3015237c4ea3f2c6081e1d087c0a231dL85-R95) [[3]](diffhunk://#diff-fa14be17edb00f952b86f8b4cbd3afacb5385c55c372c2c28c24259b90469c7fL149-R153) [[4]](diffhunk://#diff-67cfceba493cd4c378bd8de4410c7f4a3e4e8e45a2ed9b1a7a60e2df459a4addL93-R99)
- Replaced the `Unpacker` struct and its methods with standalone functions (`Unpack`, `IsSupportedFormat`, etc.), and updated all usages and tests. (`internal/unpack.go`, `internal/asset.go`, `internal/asset_test.go`, `internal/grip.go`) [[1]](diffhunk://#diff-4005b0279afced326f5b775dad703d8fc2c76faeda917ea504436dbf3796906eL37-R54) [[2]](diffhunk://#diff-64810240c89ddea453b8fd27ed69184b3015237c4ea3f2c6081e1d087c0a231dL49-R53) [[3]](diffhunk://#diff-fa14be17edb00f952b86f8b4cbd3afacb5385c55c372c2c28c24259b90469c7fL195-R195) [[4]](diffhunk://#diff-fa14be17edb00f952b86f8b4cbd3afacb5385c55c372c2c28c24259b90469c7fL214-R213) [[5]](diffhunk://#diff-fa14be17edb00f952b86f8b4cbd3afacb5385c55c372c2c28c24259b90469c7fL225-R226) [[6]](diffhunk://#diff-fa14be17edb00f952b86f8b4cbd3afacb5385c55c372c2c28c24259b90469c7fL572-R565) [[7]](diffhunk://#diff-fa14be17edb00f952b86f8b4cbd3afacb5385c55c372c2c28c24259b90469c7fL588-R580) [[8]](diffhunk://#diff-fa14be17edb00f952b86f8b4cbd3afacb5385c55c372c2c28c24259b90469c7fL980-R970) [[9]](diffhunk://#diff-fa14be17edb00f952b86f8b4cbd3afacb5385c55c372c2c28c24259b90469c7fL994-R983) [[10]](diffhunk://#diff-fa14be17edb00f952b86f8b4cbd3afacb5385c55c372c2c28c24259b90469c7fL1009-R997) [[11]](diffhunk://#diff-67cfceba493cd4c378bd8de4410c7f4a3e4e8e45a2ed9b1a7a60e2df459a4addL93-R99)
- Replaced the `BinaryInstaller` struct and its methods with a single `InstallBinary` function, and updated all usages and tests. (`internal/binary_installer.go`, `internal/asset.go`, `internal/asset_test.go`) [[1]](diffhunk://#diff-ccabfd2f8aa573fa64f6529443de02ec079a4b52a703c71dc7bfc05f07082762L10-R37) [[2]](diffhunk://#diff-ccabfd2f8aa573fa64f6529443de02ec079a4b52a703c71dc7bfc05f07082762L48-R54) [[3]](diffhunk://#diff-ccabfd2f8aa573fa64f6529443de02ec079a4b52a703c71dc7bfc05f07082762L73-L99) [[4]](diffhunk://#diff-64810240c89ddea453b8fd27ed69184b3015237c4ea3f2c6081e1d087c0a231dL85-R95) [[5]](diffhunk://#diff-fa14be17edb00f952b86f8b4cbd3afacb5385c55c372c2c28c24259b90469c7fL252-R247) [[6]](diffhunk://#diff-fa14be17edb00f952b86f8b4cbd3afacb5385c55c372c2c28c24259b90469c7fL270-R270)

**Code simplification and cleanup:**

- Removed now-unnecessary struct methods and validation helpers, integrating validation directly into the new functions. (`internal/binary_installer.go`, `internal/unpack.go`) [[1]](diffhunk://#diff-ccabfd2f8aa573fa64f6529443de02ec079a4b52a703c71dc7bfc05f07082762L73-L99) [[2]](diffhunk://#diff-4005b0279afced326f5b775dad703d8fc2c76faeda917ea504436dbf3796906eL37-R54)
- Updated progress bar usage and error handling to fit the new function-based structure. (`internal/downloader.go`, `internal/binary_installer.go`, `internal/unpack.go`) [[1]](diffhunk://#diff-d9f42243b52b71fb8b4517902e54cbe89279a824b3dfdc71d7ecb93437c9bc98L12-R49) [[2]](diffhunk://#diff-ccabfd2f8aa573fa64f6529443de02ec079a4b52a703c71dc7bfc05f07082762L48-R54) [[3]](diffhunk://#diff-4005b0279afced326f5b775dad703d8fc2c76faeda917ea504436dbf3796906eL87-R112)

These changes make the codebase less complex, easier to read, and more idiomatic for Go.