### PR TITLE
refactor: consolidate installation pipeline by enhancing self-update …

### DIFF
--- a/cmd/update/update.go
+++ b/cmd/update/update.go
@@ -44,7 +44,7 @@ func Command(ctx context.Context, app *cli.App, installer *grip.Installer, stora
 		Name:  "self-update",
 		Usage: "updates grip",
 		Action: func(c *cli.Context) error {
-			return grip.SelfUpdate(ctx, app.Version)
+			return grip.SelfUpdate(ctx, app.Version, installer)
 		},
 	}
 

--- a/internal/asset.go
+++ b/internal/asset.go
@@ -1,10 +1,7 @@
 package grip
 
 import (
-	"context"
 	"fmt"
-	"net/http"
-	"path/filepath"
 	"strings"
 
 	"github.com/alexjoedt/grip/internal/logger"
@@ -66,35 +63,4 @@ func parseAsset(assets []*github.ReleaseAsset, cfg *Config, repoOwner, repoName 
 	return nil, fmt.Errorf("no asset found for %s_%s", cfg.OS, cfg.Arch)
 }
 
-// InstallAsset orchestrates the complete installation workflow
-func InstallAsset(ctx context.Context, asset *Asset, cfg *Config, httpClient *http.Client) error {
-	// Create workspace
-	ws, err := NewWorkspace(cfg.TempDir, asset.Name)
-	if err != nil {
-		return fmt.Errorf("create workspace: %w", err)
-	}
-	defer func() {
-		if cleanupErr := ws.Cleanup(); cleanupErr != nil {
-			logger.Error("Failed to cleanup workspace: %v", cleanupErr)
-		}
-	}()
 
-	// Download asset
-	archivePath := filepath.Join(ws.DownloadDir(), asset.Name)
-	if err := Download(ctx, httpClient, asset.DownloadURL, ws.DownloadDir(), asset.Name); err != nil {
-		return fmt.Errorf("download: %w", err)
-	}
-
-	// Unpack archive
-	execPath, err := Unpack(archivePath, ws.UnpackDir())
-	if err != nil {
-		return fmt.Errorf("unpack: %w", err)
-	}
-
-	// Install binary
-	if err := InstallBinary(execPath, cfg.BinDir, asset.BinaryName()); err != nil {
-		return fmt.Errorf("install: %w", err)
-	}
-
-	return nil
-}

--- a/internal/grip.go
+++ b/internal/grip.go
@@ -17,6 +17,19 @@ const (
 )
 
 func SelfUpdate(ctx context.Context, version string, installer *Installer) error {
+	if installer == nil {
+		return fmt.Errorf("installer is required")
+	}
+	if installer.ghClient == nil {
+		return fmt.Errorf("installer: GitHub client is required")
+	}
+	if installer.config == nil {
+		return fmt.Errorf("installer: config is required")
+	}
+	if installer.httpClient == nil {
+		return fmt.Errorf("installer: HTTP client is required")
+	}
+
 	owner, name, err := ParseRepoPath(repository)
 	if err != nil {
 		return err

--- a/internal/grip.go
+++ b/internal/grip.go
@@ -3,11 +3,7 @@ package grip
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"os"
-	"path/filepath"
-	"runtime"
-	"time"
 
 	"github.com/alexjoedt/grip/internal/logger"
 	"github.com/alexjoedt/grip/internal/semver"
@@ -20,32 +16,14 @@ const (
 	repository = "github.com/alexjoedt/grip"
 )
 
-var (
-	currentOS   = runtime.GOOS
-	currentArch = runtime.GOARCH
-
-	// osAliases common aliases used in release packages
-	osAliases = map[string][]string{
-		"darwin": {"macos"},
-		"linux":  {"musl"},
-	}
-
-	// archAliases common aliases used in release packages
-	archAliases = map[string][]string{
-		"amd64": {"x86_64"},
-		"arm64": {"aarch64", "universal"},
-	}
-)
-
-func SelfUpdate(ctx context.Context, version string) error {
+func SelfUpdate(ctx context.Context, version string, installer *Installer) error {
 	owner, name, err := ParseRepoPath(repository)
 	if err != nil {
 		return err
 	}
 
 	// Fetch latest release
-	ghClient := NewGitHubClient()
-	release, err := ghClient.GetLatestRelease(ctx, owner, name)
+	release, err := installer.ghClient.GetLatestRelease(ctx, owner, name)
 	if err != nil {
 		return err
 	}
@@ -71,35 +49,18 @@ func SelfUpdate(ctx context.Context, version string) error {
 	}
 
 	// Parse asset for current platform
-	cfg, err := DefaultConfig()
-	if err != nil {
-		return err
-	}
-
-	asset, err := parseAsset(release.Assets, cfg, owner, name)
+	asset, err := parseAsset(release.Assets, installer.config, owner, name)
 	if err != nil {
 		return err
 	}
 	asset.Tag = latestTag
 
-	// Create workspace for download and unpack
-	ws, err := NewWorkspace(cfg.TempDir, "grip-selfupdate")
+	// Download and unpack using installer
+	binPath, cleanup, err := installer.downloadAndUnpack(ctx, asset)
 	if err != nil {
-		return fmt.Errorf("create workspace: %w", err)
+		return err
 	}
-	defer ws.Cleanup()
-
-	// Download
-	if err := Download(ctx, &http.Client{Timeout: 30 * time.Second}, asset.DownloadURL, ws.DownloadDir(), asset.Name); err != nil {
-		return fmt.Errorf("download: %w", err)
-	}
-
-	// Unpack
-	archivePath := filepath.Join(ws.DownloadDir(), asset.Name)
-	binPath, err := Unpack(archivePath, ws.UnpackDir())
-	if err != nil {
-		return fmt.Errorf("unpack: %w", err)
-	}
+	defer cleanup()
 
 	// Apply self-update
 	reader, err := os.Open(binPath)

--- a/internal/installer.go
+++ b/internal/installer.go
@@ -97,8 +97,8 @@ func (i *Installer) Install(ctx context.Context, opts InstallOptions) error {
 	asset.Tag = *release.TagName
 	asset.Alias = opts.Alias
 
-	// Install using orchestration function
-	if err := InstallAsset(ctx, asset, i.config, i.httpClient); err != nil {
+	// Install asset
+	if err := i.installAsset(ctx, asset); err != nil {
 		return fmt.Errorf("install: %w", err)
 	}
 
@@ -152,6 +152,49 @@ func (i *Installer) Update(ctx context.Context, name string) error {
 	}
 
 	return i.Install(ctx, opts)
+}
+
+// downloadAndUnpack downloads an asset archive and unpacks it.
+// Returns the path to the extracted executable and a cleanup function.
+// The caller is responsible for calling cleanup when done.
+func (i *Installer) downloadAndUnpack(ctx context.Context, asset *Asset) (string, func(), error) {
+	ws, err := NewWorkspace(i.config.TempDir, asset.Name)
+	if err != nil {
+		return "", nil, fmt.Errorf("create workspace: %w", err)
+	}
+	cleanup := func() {
+		if cleanupErr := ws.Cleanup(); cleanupErr != nil {
+			logger.Error("Failed to cleanup workspace: %v", cleanupErr)
+		}
+	}
+
+	if err := Download(ctx, i.httpClient, asset.DownloadURL, ws.DownloadDir(), asset.Name); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("download: %w", err)
+	}
+
+	archivePath := filepath.Join(ws.DownloadDir(), asset.Name)
+	binPath, err := Unpack(archivePath, ws.UnpackDir())
+	if err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("unpack: %w", err)
+	}
+
+	return binPath, cleanup, nil
+}
+
+// installAsset orchestrates the complete installation workflow for an asset.
+func (i *Installer) installAsset(ctx context.Context, asset *Asset) error {
+	binPath, cleanup, err := i.downloadAndUnpack(ctx, asset)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	if err := InstallBinary(binPath, i.config.BinDir, asset.BinaryName()); err != nil {
+		return fmt.Errorf("install: %w", err)
+	}
+	return nil
 }
 
 // Remove removes an installed package


### PR DESCRIPTION
This pull request refactors the installation and self-update logic to improve code organization, encapsulation, and error handling. The main changes move asset installation and workspace management into methods of the `Installer` struct, making the codebase more modular and maintainable.

**Refactoring and encapsulation:**

* Moved the asset installation workflow from the standalone `InstallAsset` function in `internal/asset.go` into a new `Installer.installAsset` method and removed the old function, centralizing installation logic within the `Installer` struct. [[1]](diffhunk://#diff-64810240c89ddea453b8fd27ed69184b3015237c4ea3f2c6081e1d087c0a231dL69-L100) [[2]](diffhunk://#diff-6b7cd44caf2e058e7423ebe372e675d6f6319a85926ffbd65144cb55ea7afea2L100-R101) [[3]](diffhunk://#diff-6b7cd44caf2e058e7423ebe372e675d6f6319a85926ffbd65144cb55ea7afea2R157-R199)
* Added the `Installer.downloadAndUnpack` method to handle downloading and unpacking assets, returning the binary path and a cleanup function to ensure proper resource management.

**Self-update improvements:**

* Updated the `SelfUpdate` function in `internal/grip.go` to accept an `Installer` parameter instead of creating its own dependencies, and refactored it to use the installer’s configuration and download logic, improving testability and consistency. [[1]](diffhunk://#diff-67cfceba493cd4c378bd8de4410c7f4a3e4e8e45a2ed9b1a7a60e2df459a4addL23-R26) [[2]](diffhunk://#diff-67cfceba493cd4c378bd8de4410c7f4a3e4e8e45a2ed9b1a7a60e2df459a4addL74-R63) [[3]](diffhunk://#diff-6060d6b8c156ae366fdfc75f287e3cf760a2a43dee32f29f9f8b156ee0cf5bb2L47-R47)

**Code cleanup:**

* Removed unused imports and variables related to HTTP, file paths, and runtime from `internal/asset.go` and `internal/grip.go`, reducing clutter and potential confusion. [[1]](diffhunk://#diff-64810240c89ddea453b8fd27ed69184b3015237c4ea3f2c6081e1d087c0a231dL4-L7) [[2]](diffhunk://#diff-67cfceba493cd4c378bd8de4410c7f4a3e4e8e45a2ed9b1a7a60e2df459a4addL6-L10) [[3]](diffhunk://#diff-67cfceba493cd4c378bd8de4410c7f4a3e4e8e45a2ed9b1a7a60e2df459a4addL23-R26)…and asset handling