### PR TITLE
refactor: remove unnecessary parameters and deduplicate logic in comm…

### DIFF
--- a/cmd/install/install.go
+++ b/cmd/install/install.go
@@ -7,7 +7,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func Command(ctx context.Context, app *cli.App, installer *grip.Installer, cfg *grip.Config) {
+func Command(ctx context.Context, app *cli.App, installer *grip.Installer) {
 	cmd := &cli.Command{
 		Name:  "install",
 		Usage: "install an executable from a GitHub release",
@@ -16,12 +16,6 @@ func Command(ctx context.Context, app *cli.App, installer *grip.Installer, cfg *
 				Name:    "tag",
 				Aliases: []string{"t"},
 				Usage:   "release tag",
-			},
-			&cli.StringFlag{
-				Name:    "destination",
-				Aliases: []string{"d"},
-				Usage:   "specifies the installation path",
-				Value:   cfg.BinDir,
 			},
 			&cli.BoolFlag{
 				Name:    "force",
@@ -36,11 +30,10 @@ func Command(ctx context.Context, app *cli.App, installer *grip.Installer, cfg *
 		},
 		Action: func(c *cli.Context) error {
 			opts := grip.InstallOptions{
-				Repo:        c.Args().First(),
-				Tag:         c.String("tag"),
-				Destination: c.String("destination"),
-				Force:       c.Bool("force"),
-				Alias:       c.String("alias"),
+				Repo:  c.Args().First(),
+				Tag:   c.String("tag"),
+				Force: c.Bool("force"),
+				Alias: c.String("alias"),
 			}
 
 			return installer.Install(ctx, opts)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -80,10 +80,10 @@ func main() {
 	}
 
 	versionCommand(app)
-	install.Command(ctx, app, installer, cfg)
+	install.Command(ctx, app, installer)
 	update.Command(ctx, app, installer, storage, cfg)
 	list.Command(app, storage)
-	remove.Command(app, storage, cfg)
+	remove.Command(app, installer, storage)
 
 	if err := app.Run(os.Args); err != nil {
 		logger.Error("%s", err.Error())

--- a/cmd/remove/remove.go
+++ b/cmd/remove/remove.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	grip "github.com/alexjoedt/grip/internal"
@@ -12,7 +11,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-func Command(app *cli.App, storage *grip.Storage, cfg *grip.Config) {
+func Command(app *cli.App, installer *grip.Installer, storage *grip.Storage) {
 	cmd := &cli.Command{
 		Name:        "remove",
 		Usage:       "removes an installed executable by grip",
@@ -43,18 +42,10 @@ func Command(app *cli.App, storage *grip.Storage, cfg *grip.Config) {
 				}
 
 				for _, inst := range installations {
-					p := filepath.Join(inst.InstallPath, inst.Name)
-					if err := os.Remove(p); err != nil && !os.IsNotExist(err) {
-						logger.Error("Failed to remove: %s", p)
+					if err := installer.Remove(inst.Name); err != nil {
+						logger.Error("Failed to remove %s: %v", inst.Name, err)
 						continue
 					}
-
-					if err := storage.Delete(inst.Name); err != nil {
-						logger.Error("Failed to update storage: %v", err)
-						continue
-					}
-
-					logger.Success("Removed: %s", p)
 				}
 				return nil
 			}
@@ -68,28 +59,13 @@ func Command(app *cli.App, storage *grip.Storage, cfg *grip.Config) {
 				return fmt.Errorf("please provide the name or alias, not the repo path")
 			}
 
-			inst, err := storage.Get(name)
-			if err != nil {
-				return fmt.Errorf("package not found: %s", name)
-			}
-
 			if !c.Bool("force") {
 				if !askForContinue() {
 					return nil
 				}
 			}
 
-			p := filepath.Join(inst.InstallPath, inst.Name)
-			if err := os.Remove(p); err != nil {
-				return fmt.Errorf("failed to remove binary: %w", err)
-			}
-
-			if err := storage.Delete(inst.Name); err != nil {
-				return fmt.Errorf("failed to update storage: %w", err)
-			}
-
-			logger.Success("Removed: %s", name)
-			return nil
+			return installer.Remove(name)
 		},
 	}
 	app.Commands = append(app.Commands, cmd)

--- a/internal/installer.go
+++ b/internal/installer.go
@@ -146,7 +146,7 @@ func (i *Installer) Update(ctx context.Context, name string) error {
 		Repo:  inst.Repo,
 		Tag:   "", // Get latest
 		Force: true,
-		Alias:       inst.Alias,
+		Alias: inst.Alias,
 	}
 
 	return i.Install(ctx, opts)

--- a/internal/installer.go
+++ b/internal/installer.go
@@ -44,11 +44,10 @@ func (i *Installer) Config() *Config {
 
 // InstallOptions holds installation parameters
 type InstallOptions struct {
-	Repo        string
-	Tag         string
-	Destination string
-	Force       bool
-	Alias       string
+	Repo  string
+	Tag   string
+	Force bool
+	Alias string
 }
 
 // Install installs a package from GitHub
@@ -144,10 +143,9 @@ func (i *Installer) Update(ctx context.Context, name string) error {
 
 	// Install with force flag
 	opts := InstallOptions{
-		Repo:        inst.Repo,
-		Tag:         "", // Get latest
-		Destination: inst.InstallPath,
-		Force:       true,
+		Repo:  inst.Repo,
+		Tag:   "", // Get latest
+		Force: true,
 		Alias:       inst.Alias,
 	}
 

--- a/internal/storage.go
+++ b/internal/storage.go
@@ -257,11 +257,6 @@ func parseOldLockFile(path string) ([]repoEntry, error) {
 	return entries, scanner.Err()
 }
 
-// CalculateFileSHA256 computes the SHA256 hash of a file (exported for use in commands)
-func CalculateFileSHA256(path string) (string, error) {
-	return calculateFileSHA256(path)
-}
-
 // calculateFileSHA256 computes the SHA256 hash of a file
 func calculateFileSHA256(path string) (string, error) {
 	f, err := os.Open(path)


### PR DESCRIPTION
This pull request refactors the install and remove command implementations to simplify their interfaces and improve maintainability. The main changes include removing the `destination` option from installation, refactoring the remove logic to use the `Installer` abstraction, and updating function signatures for better consistency.

**Command interface and options refactoring:**

* Removed the `destination` flag from the `install` command and the corresponding field from `InstallOptions`, simplifying the install process and reducing configuration complexity. (`cmd/install/install.go` [[1]](diffhunk://#diff-b105e0fd290117fe4056a1e2270006e9ea7a6025f5b57936dff42d50660e0b9cL10-R10) [[2]](diffhunk://#diff-b105e0fd290117fe4056a1e2270006e9ea7a6025f5b57936dff42d50660e0b9cL20-L25) [[3]](diffhunk://#diff-b105e0fd290117fe4056a1e2270006e9ea7a6025f5b57936dff42d50660e0b9cL41); `internal/installer.go` [[4]](diffhunk://#diff-6b7cd44caf2e058e7423ebe372e675d6f6319a85926ffbd65144cb55ea7afea2L49) [[5]](diffhunk://#diff-6b7cd44caf2e058e7423ebe372e675d6f6319a85926ffbd65144cb55ea7afea2L149)
* Updated the `install.Command` and `remove.Command` function signatures to remove unused parameters and to pass the `Installer` where needed, improving clarity and consistency. (`cmd/install/install.go` [[1]](diffhunk://#diff-b105e0fd290117fe4056a1e2270006e9ea7a6025f5b57936dff42d50660e0b9cL10-R10); `cmd/main.go` [[2]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L83-R86); `cmd/remove/remove.go` [[3]](diffhunk://#diff-189480ab096c6d7b6a28710d380aeb21d59e6843726ecf0a8edbee68574a5b5cL7-R14)

**Removal logic improvements:**

* Refactored the remove command to delegate removal logic to the `Installer.Remove` method, centralizing removal logic and error handling. (`cmd/remove/remove.go` [[1]](diffhunk://#diff-189480ab096c6d7b6a28710d380aeb21d59e6843726ecf0a8edbee68574a5b5cL46-L57) [[2]](diffhunk://#diff-189480ab096c6d7b6a28710d380aeb21d59e6843726ecf0a8edbee68574a5b5cL71-R68)

**Code cleanup:**

* Removed the exported `CalculateFileSHA256` function from `internal/storage.go`, as it is no longer needed. (`internal/storage.go` [internal/storage.goL260-L264](diffhunk://#diff-c0090d5a11ac63f548ac55ed4e0f2b804931356f733357016c3d66b80a7daed1L260-L264))…and functions