### PR TITLE
refactor: reorganize progress bar functionality and remove unused mutex

### DIFF
--- a/internal/grip.go
+++ b/internal/grip.go
@@ -7,9 +7,7 @@ import (
 
 	"github.com/alexjoedt/grip/internal/logger"
 	"github.com/alexjoedt/grip/internal/semver"
-	"github.com/k0kubun/go-ansi"
 	"github.com/minio/selfupdate"
-	"github.com/schollz/progressbar/v3"
 )
 
 const (
@@ -88,20 +86,4 @@ func SelfUpdate(ctx context.Context, version string, installer *Installer) error
 
 	logger.Success("Grip updated successfully to %s", asset.Tag)
 	return nil
-}
-
-func NewProgressBar(size int, description string) *progressbar.ProgressBar {
-	return progressbar.NewOptions(size,
-		progressbar.OptionFullWidth(),
-		progressbar.OptionSetWriter(ansi.NewAnsiStdout()),
-		progressbar.OptionEnableColorCodes(true),
-		progressbar.OptionShowBytes(true),
-		progressbar.OptionSetDescription(description),
-		progressbar.OptionSetTheme(progressbar.Theme{
-			Saucer:        "[green]=[reset]",
-			SaucerHead:    "[green]>[reset]",
-			SaucerPadding: " ",
-			BarStart:      "[",
-			BarEnd:        "]",
-		}))
 }

--- a/internal/progress.go
+++ b/internal/progress.go
@@ -1,0 +1,22 @@
+package grip
+
+import (
+	"github.com/k0kubun/go-ansi"
+	"github.com/schollz/progressbar/v3"
+)
+
+func NewProgressBar(size int, description string) *progressbar.ProgressBar {
+	return progressbar.NewOptions(size,
+		progressbar.OptionFullWidth(),
+		progressbar.OptionSetWriter(ansi.NewAnsiStdout()),
+		progressbar.OptionEnableColorCodes(true),
+		progressbar.OptionShowBytes(true),
+		progressbar.OptionSetDescription(description),
+		progressbar.OptionSetTheme(progressbar.Theme{
+			Saucer:        "[green]=[reset]",
+			SaucerHead:    "[green]>[reset]",
+			SaucerPadding: " ",
+			BarStart:      "[",
+			BarEnd:        "]",
+		}))
+}

--- a/internal/storage.go
+++ b/internal/storage.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"os"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -36,7 +35,6 @@ type repoEntry struct {
 // Storage manages installed packages
 type Storage struct {
 	filepath string
-	mu       sync.RWMutex
 }
 
 // NewStorage creates a new storage instance with migration from old lock file
@@ -67,9 +65,6 @@ func NewStorage(filepath string, cfg *Config) (*Storage, error) {
 
 // Get retrieves installation by name
 func (s *Storage) Get(name string) (*Installation, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	data, err := s.load()
 	if err != nil {
 		return nil, err
@@ -85,9 +80,6 @@ func (s *Storage) Get(name string) (*Installation, error) {
 
 // GetByRepo retrieves installation by repository path
 func (s *Storage) GetByRepo(repo string) (*Installation, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	data, err := s.load()
 	if err != nil {
 		return nil, err
@@ -104,9 +96,6 @@ func (s *Storage) GetByRepo(repo string) (*Installation, error) {
 
 // List returns all installations
 func (s *Storage) List() ([]*Installation, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
 	data, err := s.load()
 	if err != nil {
 		return nil, err
@@ -122,9 +111,6 @@ func (s *Storage) List() ([]*Installation, error) {
 
 // Save stores or updates an installation
 func (s *Storage) Save(inst *Installation) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	data, err := s.load()
 	if err != nil {
 		return err
@@ -136,9 +122,6 @@ func (s *Storage) Save(inst *Installation) error {
 
 // Delete removes an installation by name
 func (s *Storage) Delete(name string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	data, err := s.load()
 	if err != nil {
 		return err

--- a/internal/workspace.go
+++ b/internal/workspace.go
@@ -11,7 +11,6 @@ type Workspace struct {
 	rootDir     string
 	downloadDir string
 	unpackDir   string
-	created     bool
 }
 
 // NewWorkspace creates a new workspace with temporary directories
@@ -29,7 +28,6 @@ func NewWorkspace(baseTempDir, prefix string) (*Workspace, error) {
 		rootDir:     rootDir,
 		downloadDir: filepath.Join(rootDir, "download"),
 		unpackDir:   filepath.Join(rootDir, "unpack"),
-		created:     true,
 	}
 
 	if err := os.MkdirAll(ws.downloadDir, 0755); err != nil {
@@ -62,7 +60,7 @@ func (w *Workspace) RootDir() string {
 
 // Cleanup removes all workspace directories
 func (w *Workspace) Cleanup() error {
-	if !w.created || w.rootDir == "" {
+	if w.rootDir == "" {
 		return nil
 	}
 
@@ -70,6 +68,6 @@ func (w *Workspace) Cleanup() error {
 		return fmt.Errorf("cleanup workspace: %w", err)
 	}
 
-	w.created = false
+	w.rootDir = ""
 	return nil
 }

--- a/internal/workspace.go
+++ b/internal/workspace.go
@@ -69,5 +69,7 @@ func (w *Workspace) Cleanup() error {
 	}
 
 	w.rootDir = ""
+	w.downloadDir = ""
+	w.unpackDir = ""
 	return nil
 }


### PR DESCRIPTION
This pull request refactors and simplifies parts of the codebase, primarily by moving the progress bar logic to its own file, removing unnecessary synchronization from the `Storage` struct, and cleaning up the `Workspace` struct. The changes improve code organization and reduce complexity, especially around concurrency and resource management.

**Progress Bar Refactoring:**

* Moved the `NewProgressBar` function and related imports from `internal/grip.go` to a new file `internal/progress.go`, improving separation of concerns and code organization. [[1]](diffhunk://#diff-67cfceba493cd4c378bd8de4410c7f4a3e4e8e45a2ed9b1a7a60e2df459a4addL10-L12) [[2]](diffhunk://#diff-67cfceba493cd4c378bd8de4410c7f4a3e4e8e45a2ed9b1a7a60e2df459a4addL92-L107) [[3]](diffhunk://#diff-5cd4e480cf6217a7cea5db2ca1bc8e6d188484560f8ace5121505b023fd899d4R1-R22)

**Storage Synchronization Simplification:**

* Removed the `sync.RWMutex` and all locking/unlocking logic from the `Storage` struct and its methods, simplifying the code and assuming that concurrency control is not needed at this layer. [[1]](diffhunk://#diff-c0090d5a11ac63f548ac55ed4e0f2b804931356f733357016c3d66b80a7daed1L12) [[2]](diffhunk://#diff-c0090d5a11ac63f548ac55ed4e0f2b804931356f733357016c3d66b80a7daed1L39) [[3]](diffhunk://#diff-c0090d5a11ac63f548ac55ed4e0f2b804931356f733357016c3d66b80a7daed1L70-L72) [[4]](diffhunk://#diff-c0090d5a11ac63f548ac55ed4e0f2b804931356f733357016c3d66b80a7daed1L88-L90) [[5]](diffhunk://#diff-c0090d5a11ac63f548ac55ed4e0f2b804931356f733357016c3d66b80a7daed1L107-L109) [[6]](diffhunk://#diff-c0090d5a11ac63f548ac55ed4e0f2b804931356f733357016c3d66b80a7daed1L125-L127) [[7]](diffhunk://#diff-c0090d5a11ac63f548ac55ed4e0f2b804931356f733357016c3d66b80a7daed1L139-L141)

**Workspace Cleanup Logic:**

* Removed the `created` field from the `Workspace` struct and its usage, now only relying on `rootDir` to determine if cleanup is needed, which simplifies state management for temporary directories. [[1]](diffhunk://#diff-d3704df9393805b86b372830835589aa3776dc21a80f2e49a4ce710170ff5feeL14) [[2]](diffhunk://#diff-d3704df9393805b86b372830835589aa3776dc21a80f2e49a4ce710170ff5feeL32) [[3]](diffhunk://#diff-d3704df9393805b86b372830835589aa3776dc21a80f2e49a4ce710170ff5feeL65-R71)